### PR TITLE
feat(password) implement forgot password functionality

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,3 @@
 export const redisSessionPrefix = 'sess:';
 export const userSessionIDPrefix = 'userSids:';
+export const forgotPasswordPrefix = 'forgotPassword';

--- a/src/entity/User.ts
+++ b/src/entity/User.ts
@@ -4,7 +4,7 @@ import {
   BaseEntity,
   PrimaryGeneratedColumn,
   OneToMany,
-  BeforeInsert
+  BeforeInsert,
 } from "typeorm";
 
 import * as bcrypt from 'bcryptjs';
@@ -35,6 +35,9 @@ export class User extends BaseEntity {
   @Column("boolean", { default: false })
   confirmed: boolean;
 
+  @Column("boolean", { default: false })
+  forgotPasswordLocked: boolean
+
   // @ts-ignore `type` is not being used
   @OneToMany(type => Task, task => task.creator)
   tasks: Task[];
@@ -56,7 +59,7 @@ export class User extends BaseEntity {
   approvedResolutions: UserApprovalTaskResolution[];
 
   @BeforeInsert()
-  async hashPassword() {
+  async hashPasswordBeforeInsert() {
     this.password = await bcrypt.hash(this.password, 10);
   }
 }

--- a/src/modules/forgot-password/__tests__/forgotPassword.test.ts
+++ b/src/modules/forgot-password/__tests__/forgotPassword.test.ts
@@ -1,0 +1,86 @@
+import { Connection } from 'typeorm';
+import { createTypeormConn } from '../../../utils/createTypeormConn';
+import { User } from '../../../entity/User';
+import * as casual from 'casual';
+
+import { TestClient } from '../../../utils/TestClient';
+import { createForgotPasswordLink } from '../../../utils/createForgotPasswordLink';
+import * as Redis from 'ioredis';
+import { forgotPasswordLocked } from '../../login/errorMessages';
+import { passwordTooShort } from '../../register/errorMessages';
+import { expiredForgotPasswordKey } from '../errorMessages';
+import { forgotPasswordLockAccount } from '../../../utils/forgotPasswordLockAccount';
+
+let conn: Connection;
+const redis = new Redis();
+let email = casual.email;
+let password = casual.password;
+let userId: string;
+
+const newPassword = casual.password;
+
+beforeAll(async() => {
+  conn = await createTypeormConn();
+  const user = await User.create({
+    email: email,
+    password: password,
+    confirmed: true,
+  }).save();
+  userId = user.id;
+})
+
+afterAll(async () => {
+  conn.close();
+});
+
+describe('Forgot password test', () => {
+  test('Can update forgotten password and login', async() => {
+    const client = new TestClient(process.env.TEST_HOST as string);
+
+    await forgotPasswordLockAccount(userId, redis);
+    // Lock account and send email
+    const url = await createForgotPasswordLink("", userId, redis);
+    const parts = url.split('/');
+    const key = parts[parts.length - 1];
+
+    // Make sure we can't login if account locked
+    expect(await client.login(email, password)).toEqual({
+      data: {
+        login: [{
+          path: 'login',
+          message: forgotPasswordLocked
+        }]
+      }
+    });
+
+    // Try invalid password (too short)
+    expect(await client.forgotPasswordChange('a', key)).toEqual({
+      data: {
+        forgotPasswordChange: [{
+          path: 'newPassword',
+          message: passwordTooShort
+        }]
+      }
+    });
+
+    const response = await client.forgotPasswordChange(newPassword, key);
+    expect(response.data).toEqual({
+      forgotPasswordChange: null
+    });
+
+    // Make sure redis key expires after password change
+    const badResponse = await client.forgotPasswordChange(newPassword, key);
+    expect(badResponse.data).toEqual({
+      forgotPasswordChange: [{
+        path: 'newPassword',
+        message: expiredForgotPasswordKey
+      }]
+    });
+
+    expect(await client.login(email, newPassword)).toEqual({
+      data: {
+        login: null
+      }
+    });
+  });
+});

--- a/src/modules/forgot-password/errorMessages.ts
+++ b/src/modules/forgot-password/errorMessages.ts
@@ -1,0 +1,2 @@
+export const expiredForgotPasswordKey = 'forgot password key has expired';
+export const userNotFoundError = 'could not find user with that email';

--- a/src/modules/forgot-password/resolvers.ts
+++ b/src/modules/forgot-password/resolvers.ts
@@ -1,0 +1,85 @@
+import * as yup from 'yup';
+import * as bcrypt from 'bcryptjs';
+
+import { ResolverMap } from "../../types/graphql-utils";
+import { forgotPasswordLockAccount } from "../../utils/forgotPasswordLockAccount";
+import { createForgotPasswordLink } from "../../utils/createForgotPasswordLink";
+import { User } from "../../entity/User";
+import { userNotFoundError, expiredForgotPasswordKey } from "./errorMessages";
+import { forgotPasswordPrefix } from "../../constants";
+import { registerPasswordValidation } from "../../yupSchemas";
+import { formatYupError } from '../../utils/formatYupError';
+
+
+const schema = yup.object().shape({
+  newPassword: registerPasswordValidation
+});
+
+export const resolvers: ResolverMap = {
+  Query: {
+    dummy3: () => "dummy"
+  },
+  Mutation: {
+    sendForgotPasswordEmail: async (
+      _,
+      { email }: GQL.ISendForgotPasswordEmailOnMutationArguments,
+      { redis }
+    ) => {
+      const user = await User.findOne({ where: { email } });
+      if (!user) {
+        return [{
+          path: 'email',
+          message: userNotFoundError,
+        }];
+      }
+
+      await forgotPasswordLockAccount(user.id, redis);
+      await createForgotPasswordLink(
+        process.env.FRONTEND_HOST as string,
+        user.id,
+        redis,
+      );
+
+      // @todo send email with url
+
+      return true;
+    },
+    forgotPasswordChange: async (
+      _,
+      { newPassword, key }: GQL.IForgotPasswordChangeOnMutationArguments,
+      { redis }
+    ) => {
+
+      const redisKey = `${forgotPasswordPrefix}${key}`;
+
+      const userId = await redis.get(redisKey);
+      if (!userId) {
+        return [{
+          path: 'newPassword',
+          message: expiredForgotPasswordKey
+        }]
+      }
+
+      try {
+        await schema.validate({ newPassword }, { abortEarly: false });
+      } catch(err) {
+        return formatYupError(err);
+      }
+
+      const hashedPassword = await bcrypt.hash(newPassword, 10);
+
+      const updatePromise = await User.update({
+        id: userId
+      }, {
+        forgotPasswordLocked: false,
+        password: hashedPassword
+      });
+
+      const deleteKeyPromise = await redis.del(redisKey);
+      await Promise.all([updatePromise, deleteKeyPromise]);
+
+      return null;
+    }
+  }
+}
+

--- a/src/modules/forgot-password/schema.graphql
+++ b/src/modules/forgot-password/schema.graphql
@@ -1,0 +1,10 @@
+# import Error from "../../shared.graphql"
+
+type Query {
+  dummy3: String
+}
+
+type Mutation {
+  sendForgotPasswordEmail(email: String!): Boolean
+  forgotPasswordChange(newPassword: String!, key: String!): [Error!]
+}

--- a/src/modules/login/errorMessages.ts
+++ b/src/modules/login/errorMessages.ts
@@ -1,2 +1,3 @@
 export const invalidLogin = 'invalid login';
 export const confirmEmailError = 'please confirm your account';
+export const forgotPasswordLocked = 'you requested a password change, account is locked';

--- a/src/modules/logout/resolvers.ts
+++ b/src/modules/logout/resolvers.ts
@@ -1,5 +1,5 @@
 import { ResolverMap } from "../../types/graphql-utils";
-import { userSessionIDPrefix, redisSessionPrefix } from "../../constants";
+import { removeAllUserSessions } from "../../utils/removeAllUserSessions";
 
 export const resolvers: ResolverMap = {
   Query: {
@@ -9,17 +9,7 @@ export const resolvers: ResolverMap = {
     logout: async (_, __, { session, redis }) => {
       const { userId } = session;
       if (userId) {
-        const sessionIds = await redis.lrange(
-          `${userSessionIDPrefix}${userId}`,
-          0,
-          -1
-        );
-
-        const promises = [];
-        for (let i = 0; i < sessionIds.length; i += 1) {
-          promises.push(redis.del(`${redisSessionPrefix}${sessionIds[i]}`));
-        }
-        await Promise.all(promises);
+        await removeAllUserSessions(userId, redis);
         return true;
       }
 

--- a/src/modules/register/resolvers.ts
+++ b/src/modules/register/resolvers.ts
@@ -3,9 +3,10 @@ import * as yup from "yup";
 import { ResolverMap } from "../../types/graphql-utils";
 import { User } from '../../entity/User';
 import { formatYupError } from '../../utils/formatYupError';
-import { duplicateEmail, emailNotLongEnough, emailNotValid, passwordTooShort } from './errorMessages';
+import { duplicateEmail, emailNotLongEnough, emailNotValid } from './errorMessages';
 import { createConfirmEmailLink } from '../../utils/createConfirmEmailLink';
 import { sendEmail } from '../../utils/sendEmail';
+import { registerPasswordValidation } from "../../yupSchemas";
 
 const schema = yup.object().shape({
   email: yup
@@ -13,10 +14,7 @@ const schema = yup.object().shape({
     .min(3, emailNotLongEnough)
     .max(255)
     .email(emailNotValid),
-  password: yup
-    .string()
-    .min(3, passwordTooShort)
-    .max(255)
+  password: registerPasswordValidation
 });
 
 export const resolvers: ResolverMap = {

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -22,6 +22,7 @@ column: number;
 
 interface IQuery {
 __typename: "Query";
+dummy3: string | null;
 
 /**
  * List all incident reports in the system
@@ -125,7 +126,7 @@ latitude: number;
 longitude: number;
 type: IncidentReportType | null;
 status: IncidentReportStatus | null;
-comments: Array<IIncidentReportComment>;
+comments: Array<IIncidentReportComment> | null;
 }
 
 interface IUser {
@@ -143,7 +144,7 @@ lastName: string | null;
 OTHER = 'OTHER',
 PARKING = 'PARKING',
 TRASH = 'TRASH'
-}
+};
 
 /**
  * The status of the report, as marked by the city representatives
@@ -153,7 +154,7 @@ NEW = 'NEW',
 TRIAGED = 'TRIAGED',
 SOLVED = 'SOLVED',
 DENIED = 'DENIED'
-}
+};
 
 /**
  * A comment can be made by either citizens, or city representatives. It doesn't
@@ -196,6 +197,8 @@ task: ITask;
 
 interface IMutation {
 __typename: "Mutation";
+sendForgotPasswordEmail: boolean | null;
+forgotPasswordChange: Array<IError>;
 
 /**
  * Create a brand new incident report. Can be done by either citizens or city representatives
@@ -231,6 +234,15 @@ createOnDemandTaskResolution: Array<IError>;
 createUserApprovalTaskResolution: Array<IError>;
 createDueDateTaskResolution: Array<IError>;
 updateUser: Array<MaybeUser>;
+}
+
+interface ISendForgotPasswordEmailOnMutationArguments {
+email: string;
+}
+
+interface IForgotPasswordChangeOnMutationArguments {
+newPassword: string;
+key: string;
 }
 
 interface ICreateIncidentReportOnMutationArguments {
@@ -302,10 +314,16 @@ firstName?: string | null;
 lastName?: string | null;
 }
 
+interface IError {
+__typename: "Error";
+path: string;
+message: string;
+}
+
 /**
  * We use the same input for both updates and creations of incident reports so the only mandatory field
 * is userId. For the rest, it depends on the mutation being performed.
-*
+* 
 * TODO: Group latitude and longitude into a separate mandatory input. There is no use case for updating
 * just the longitude or the latitude.
  */
@@ -321,12 +339,6 @@ userId: string;
 type MaybeIncidentReport = IError | IIncidentReport;
 
 
-
-interface IError {
-__typename: "Error";
-path: string;
-message: string;
-}
 
 /**
  * If the status for an incident report is being updated, we only care for the new status and who

--- a/src/utils/TestClient.ts
+++ b/src/utils/TestClient.ts
@@ -27,6 +27,18 @@ export class TestClient {
     })
   }
 
+  async forgotPasswordChange(newPassword: string, key: string) {
+    return this._request(`
+        mutation {
+          forgotPasswordChange(newPassword: "${newPassword}", key: "${key}") {
+            path
+            message
+          }
+        }
+      `
+    );
+  }
+
   async login(email: string, password: string) {
     return this._request(`
         mutation {

--- a/src/utils/createConfirmEmailLink.ts
+++ b/src/utils/createConfirmEmailLink.ts
@@ -8,7 +8,7 @@ export const createConfirmEmailLink = async (
   redis: Redis
 ) => {
   const id = v4();
-  // console.log("Setting id " + id + " for " + userId);
+  // Account confirmation valid for 24 hours
   await redis.set(id, userId, 'ex', 60*60*24);
 
   let finalUrl = `${url}/confirm/${id}`;

--- a/src/utils/createForgotPasswordLink.ts
+++ b/src/utils/createForgotPasswordLink.ts
@@ -1,0 +1,17 @@
+import { v4 } from 'uuid';
+import { Redis } from 'ioredis';
+import { forgotPasswordPrefix } from '../constants';
+
+// https://foo.com => https://foo.com/change-password/<id>
+export const createForgotPasswordLink = async (
+  url: string,
+  userId: string,
+  redis: Redis
+) => {
+  const id = v4();
+  // Forgot password token valid for the next 20 minutes
+  await redis.set(`${forgotPasswordPrefix}${id}`, userId, 'ex', 60*20);
+
+  let finalUrl = `${url}/change-password/${id}`;
+  return finalUrl;
+}

--- a/src/utils/forgotPasswordLockAccount.ts
+++ b/src/utils/forgotPasswordLockAccount.ts
@@ -1,0 +1,8 @@
+import { Redis } from "ioredis";
+import { removeAllUserSessions } from "./removeAllUserSessions";
+import { User } from "../entity/User";
+
+export const forgotPasswordLockAccount = async (userId: string, redis: Redis) => {
+    await User.update({ id: userId }, { forgotPasswordLocked: true });
+    await removeAllUserSessions(userId, redis);
+};

--- a/src/utils/removeAllUserSessions.ts
+++ b/src/utils/removeAllUserSessions.ts
@@ -1,0 +1,16 @@
+import { userSessionIDPrefix, redisSessionPrefix } from "../constants";
+import { Redis } from "ioredis";
+
+export const removeAllUserSessions = async (userId: string, redis: Redis) => {
+  const sessionIds = await redis.lrange(
+    `${userSessionIDPrefix}${userId}`,
+    0,
+    -1
+  );
+
+  const promises = [];
+  for (let i = 0; i < sessionIds.length; i += 1) {
+    promises.push(redis.del(`${redisSessionPrefix}${sessionIds[i]}`));
+  }
+  await Promise.all(promises);
+} 

--- a/src/yupSchemas.ts
+++ b/src/yupSchemas.ts
@@ -1,0 +1,7 @@
+import * as yup from 'yup';
+import { passwordTooShort } from './modules/register/errorMessages';
+
+export const registerPasswordValidation = yup
+  .string()
+  .min(3, passwordTooShort)
+  .max(255);


### PR DESCRIPTION
When requesting forgot password:
- create forgot password link
- lock account for 20 minutes
- ask for new password to unlock and change pass

Forgot password key is generated in Redis, just like the email confirmation token. Still need to add email sending and create a more complete test case.